### PR TITLE
Add streaming for ProductToken and ViewToken

### DIFF
--- a/canvas/Persistency/Common/FindMany.h.in
+++ b/canvas/Persistency/Common/FindMany.h.in
@@ -125,7 +125,6 @@
 #include "canvas/Persistency/Common/Ptr.h"
 #include "canvas/Persistency/Common/detail/IPRHelper.h"
 #include "canvas/Persistency/Common/detail/is_handle.h"
-#include "canvas/Persistency/Provenance/ProductToken.h"
 #include "canvas/Utilities/InputTag.h"
 
 #include <initializer_list>

--- a/canvas/Persistency/Provenance/ProductToken.h
+++ b/canvas/Persistency/Provenance/ProductToken.h
@@ -36,13 +36,14 @@ namespace art {
     template <typename ProdA, typename ProdB, typename Data>
     struct safe_input_tag;
   }
-    
- template <typename T>
+
+  template <typename T>
   class ProductToken {
   public:
     using product_type = T;
 
-    friend std::ostream& operator<<(std::ostream& os, ProductToken const& tok)
+    friend std::ostream&
+    operator<<(std::ostream& os, ProductToken const& tok)
     {
       os << tok.inputTag_;
       return os;
@@ -56,7 +57,8 @@ namespace art {
     explicit ProductToken() = default;
     explicit ProductToken(InputTag const& t) : inputTag_{t} {}
 
-    InputTag const& inputTag() const
+    InputTag const&
+    inputTag() const
     {
       return inputTag_;
     }
@@ -75,7 +77,6 @@ namespace art {
     InputTag inputTag_{};
   };
 
-
   template <typename Element>
   class ViewToken {
   public:
@@ -89,13 +90,14 @@ namespace art {
     explicit ViewToken() = default;
     explicit ViewToken(InputTag const& t) : inputTag_{t} {}
 
-    InputTag const& inputTag() const
+    InputTag const&
+    inputTag() const
     {
       return inputTag_;
     }
 
-
-    friend std::ostream& operator<<(std::ostream& os, ViewToken const& tok)
+    friend std::ostream&
+    operator<<(std::ostream& os, ViewToken const& tok)
     {
       os << tok.inputTag_;
       return os;

--- a/canvas/Persistency/Provenance/ProductToken.h
+++ b/canvas/Persistency/Provenance/ProductToken.h
@@ -17,6 +17,7 @@
 
 #include "canvas/Utilities/InputTag.h"
 
+#include <ostream>
 #include <string>
 
 namespace gallery {
@@ -27,24 +28,26 @@ namespace art {
 
   template <typename T>
   class ProductToken;
+
   template <typename T>
   class ViewToken;
-
-  // Forward declarations needed for granting friendship
-  class ProductRetriever;
-  class ConsumesCollector;
 
   namespace detail {
     template <typename ProdA, typename ProdB, typename Data>
     struct safe_input_tag;
   }
-
-  template <typename T>
+    
+ template <typename T>
   class ProductToken {
   public:
     using product_type = T;
 
-  private:
+    friend std::ostream& operator<<(std::ostream& os, ProductToken const& tok)
+    {
+      os << tok.inputTag_;
+      return os;
+    }
+
     static ProductToken<T>
     invalid()
     {
@@ -53,9 +56,12 @@ namespace art {
     explicit ProductToken() = default;
     explicit ProductToken(InputTag const& t) : inputTag_{t} {}
 
-    friend class ProductRetriever;
-    friend class ConsumesCollector;
-    friend class gallery::Event;
+    InputTag const& inputTag() const
+    {
+      return inputTag_;
+    }
+
+  private:
     template <typename ProdA, typename ProdB, typename Data>
     friend struct detail::safe_input_tag;
 
@@ -69,12 +75,12 @@ namespace art {
     InputTag inputTag_{};
   };
 
+
   template <typename Element>
   class ViewToken {
   public:
     using element_type = Element;
 
-  private:
     static ViewToken<Element>
     invalid()
     {
@@ -83,9 +89,19 @@ namespace art {
     explicit ViewToken() = default;
     explicit ViewToken(InputTag const& t) : inputTag_{t} {}
 
-    friend class ProductRetriever;
-    friend class ConsumesCollector;
+    InputTag const& inputTag() const
+    {
+      return inputTag_;
+    }
 
+
+    friend std::ostream& operator<<(std::ostream& os, ViewToken const& tok)
+    {
+      os << tok.inputTag_;
+      return os;
+    }
+
+  private:
     // See notes in ProductToken re. the representation.
     InputTag inputTag_{};
   };

--- a/canvas/test/Persistency/Provenance/CMakeLists.txt
+++ b/canvas/test/Persistency/Provenance/CMakeLists.txt
@@ -7,6 +7,7 @@ endforeach()
 
 cet_test(EventRange_t USE_BOOST_UNIT LIBRARIES PRIVATE canvas::canvas)
 cet_test(FileIndex_t USE_BOOST_UNIT LIBRARIES PRIVATE canvas::canvas)
+cet_test(ProductToken_t USE_BOOST_UNIT LIBRARIES PRIVATE canvas::canvas)
 cet_test(RangeSet_t USE_BOOST_UNIT LIBRARIES PRIVATE canvas::canvas)
 cet_test(TimeStamp_t USE_BOOST_UNIT LIBRARIES PRIVATE canvas::canvas)
 

--- a/canvas/test/Persistency/Provenance/ProductToken_t.cc
+++ b/canvas/test/Persistency/Provenance/ProductToken_t.cc
@@ -1,0 +1,41 @@
+#define BOOST_TEST_MODULE (ProductToken_t)
+#include "boost/test/unit_test.hpp"
+#include "canvas/Persistency/Provenance/ProductToken.h"
+#include "canvas/Utilities/InputTag.h"
+
+#include <sstream>
+#include <string>
+
+
+BOOST_AUTO_TEST_SUITE(ProductToken_t)
+
+BOOST_AUTO_TEST_CASE(streamingProductToken)
+{
+  art::InputTag tag_x{"x"};
+  std::ostringstream os1;
+  os1 << tag_x;
+  std::string expected = os1.str();
+
+  art::ProductToken<int> token_x{tag_x};
+  std::ostringstream os2;
+  os2 << token_x;
+  std::string result = os2.str();
+  BOOST_TEST(result == expected);
+}
+
+
+BOOST_AUTO_TEST_CASE(streamingViewToken)
+{
+  art::InputTag tag_x{"x"};
+  std::ostringstream os1;
+  os1 << tag_x;
+  std::string expected = os1.str();
+
+  art::ViewToken<int> token_x{tag_x};
+  std::ostringstream os2;
+  os2 << token_x;
+  std::string result = os2.str();
+  BOOST_TEST(result == expected);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/canvas/test/Persistency/Provenance/ProductToken_t.cc
+++ b/canvas/test/Persistency/Provenance/ProductToken_t.cc
@@ -6,7 +6,6 @@
 #include <sstream>
 #include <string>
 
-
 BOOST_AUTO_TEST_SUITE(ProductToken_t)
 
 BOOST_AUTO_TEST_CASE(streamingProductToken)
@@ -22,7 +21,6 @@ BOOST_AUTO_TEST_CASE(streamingProductToken)
   std::string result = os2.str();
   BOOST_TEST(result == expected);
 }
-
 
 BOOST_AUTO_TEST_CASE(streamingViewToken)
 {


### PR DESCRIPTION
This commit also makes the ProductToken and ViewToken much less
"opaque". It moves the private constructors to the the public
interface and removes most friend declarations.
